### PR TITLE
(fix): Remove duplicate code from 33623ed

### DIFF
--- a/src/socket/index.js
+++ b/src/socket/index.js
@@ -90,41 +90,5 @@ module.exports = function (io) {
         console.log(err);
       }
     });
-
-    socket.on('listUsers', () => {
-      let allUsers = [];
-
-      for (let [key, value] of io.of('/').sockets) {
-        console.log(value.username);
-        allUsers.push(value.username);
-      }
-
-      if (allUsers.length > 0) {
-        io.to(socket.id).emit('listUsers', allUsers);
-      }
-    });
-
-    socket.on('listRoomUsers', (room) => {
-      let socketIds;
-      let members = [];
-
-      for (let [key, value] of io.of('/').adapter.rooms) {
-        if (key.toLowerCase() === room) {
-          socketIds = value;
-        }
-      }
-
-      console.log("socket id's", socketIds);
-
-      if (socketIds) {
-        socketIds.forEach((socketId) => {
-          let socketInRoom = io.of('/').sockets.get(socketId);
-          members.push(socketInRoom.username);
-        });
-        console.log('room members', members);
-
-        io.to(socket.id).emit('listRoomUsers', { members, room });
-      }
-    });
   });
 };


### PR DESCRIPTION
This fixes the `null` values that were showing up when running the /listUsers command before someone joined a room. Old event listener code was reintroduced from 33623ed, causing the /listUsers event handler to not check for truthy username properties.  